### PR TITLE
fix: SB parsed context attributes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1049,23 +1049,28 @@
       filters
     });
     request.setCriteria(criteriaGrpc);
+
     if (!this.isEmptyValue(contextAttributes)) {
-      const { typeOfValue } = require('./lib/convertValues.js');
+      const { convertParameterToGRPC, typeOfValue } = require('./lib/convertValues.js');
 
       if (typeOfValue(contextAttributes) === 'String') {
         contextAttributes = JSON.parse(contextAttributes);
       }
+
       contextAttributes.forEach(attribute => {
         let parsedAttribute = attribute;
         if (typeOfValue(attribute) === 'String') {
           parsedAttribute = JSON.parse(attribute);
         }
-        request.addContextAttributes(convertParameterToGRPC({
-          columnName: parsedAttribute.key,
-          value: parsedAttribute.value
-        }))
+        request.addContextAttributes(
+          convertParameterToGRPC({
+            columnName: parsedAttribute.key,
+            value: parsedAttribute.value
+          })
+        );
       })
     }
+
     request.setUuid(uuid);
     request.setPageSize(pageSize);
     request.setPageToken(pageToken);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adempiere/grpc-api",
-  "version": "2.9.9",
+  "version": "3.0.0",
   "description": "ADempiere Web Store write in Javascript for a node service",
   "author": "Yamel Senih",
   "contributors": [


### PR DESCRIPTION

When a Smart Browser has context_attributes, the request for records generates error


```bash
curl 'http://localhost:8080/api/adempiere/user-interface/smart-browser/browser-items?token=be50159c-29c9-4968-9527-cab667fcaa55&language=en' \
  -X POST \
  -H 'Content-Type: application/json' \
  --data-raw '{"uuid":"8aaeea60-fb40-11e8-a479-7a0060f0aa01","filters":[],"context_attributes":[{"key":"C_PaySelection_ID","value":100}]}'
```



![Screenshot_20220523_233426](https://user-images.githubusercontent.com/20288327/170118969-5de21d94-95ac-49f8-b0f2-b496c417cab1.png)
