### PR TITLE
feat: Add value to overwrite default value.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1217,35 +1217,48 @@
     fieldUuid,
     browseFieldUuid,
     columnUuid,
+    value,
     contextAttributes,
     language
   }, callback) {
     const { GetDefaultValueRequest } = require('./src/grpc/proto/business_pb.js')
-    const request = new GetDefaultValueRequest()
-    request.setProcessParameterUuid(processParameterUuid)
-    request.setFieldUuid(fieldUuid)
-    request.setBrowseFieldUuid(browseFieldUuid)
-    request.setColumnUuid(columnUuid)
+    const request = new GetDefaultValueRequest();
+    request.setProcessParameterUuid(processParameterUuid);
+    request.setFieldUuid(fieldUuid);
+    request.setBrowseFieldUuid(browseFieldUuid);
+    request.setColumnUuid(columnUuid);
     if (!this.isEmptyValue(contextAttributes)) {
       const { convertParameterToGRPC, typeOfValue } = require('./lib/convertValues.js');
       if (typeOfValue(contextAttributes) === 'String') {
         contextAttributes = JSON.parse(contextAttributes);
       }
+
       contextAttributes.forEach(attribute => {
-        let parsedAttribute = attribute
-        if (typeOfValue(contextAttributes) === 'String') {
-          parsedAttribute = JSON.parse(contextAttributes);
+        let parsedAttribute = attribute;
+        if (typeOfValue(attribute) === 'String') {
+          parsedAttribute = JSON.parse(attribute);
         }
+
         request.addContextAttributes(
           convertParameterToGRPC({
             columnName: parsedAttribute.key,
             value: parsedAttribute.value
           })
         );
-      })
+      });
     }
-    request.setClientRequest(this.createClientRequest(token, language))
-    this.getUIService().getDefaultValue(request, callback)
+
+    // set value as default value
+    if (!this.isEmptyValue(value)) {
+      const { convertValueToGRPC } = require('./lib/convertValues.js');
+      const convertedValue = convertValueToGRPC({
+        value
+      });
+      request.setValue(convertedValue);
+    }
+
+    request.setClientRequest(this.createClientRequest(token, language));
+    this.getUIService().getDefaultValue(request, callback);
   }
 
   //  Run a callout to server

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adempiere/grpc-api",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "ADempiere Web Store write in Javascript for a node service",
   "author": "Yamel Senih",
   "contributors": [

--- a/proto/business.proto
+++ b/proto/business.proto
@@ -378,7 +378,7 @@ message GetDefaultValueRequest {
 	string browse_field_uuid = 4;
 	string column_uuid = 5;
 	repeated KeyValue context_attributes = 6;
-	
+	Value value = 7;
 }
 
 // Default Value Response

--- a/src/grpc/proto/business_pb.js
+++ b/src/grpc/proto/business_pb.js
@@ -8670,7 +8670,8 @@ proto.data.GetDefaultValueRequest.toObject = function(includeInstance, msg) {
     browseFieldUuid: jspb.Message.getFieldWithDefault(msg, 4, ""),
     columnUuid: jspb.Message.getFieldWithDefault(msg, 5, ""),
     contextAttributesList: jspb.Message.toObjectList(msg.getContextAttributesList(),
-    proto_base_data_type_pb.KeyValue.toObject, includeInstance)
+    proto_base_data_type_pb.KeyValue.toObject, includeInstance),
+    value: (f = msg.getValue()) && proto_base_data_type_pb.Value.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -8732,6 +8733,11 @@ proto.data.GetDefaultValueRequest.deserializeBinaryFromReader = function(msg, re
       var value = new proto_base_data_type_pb.KeyValue;
       reader.readMessage(value,proto_base_data_type_pb.KeyValue.deserializeBinaryFromReader);
       msg.addContextAttributes(value);
+      break;
+    case 7:
+      var value = new proto_base_data_type_pb.Value;
+      reader.readMessage(value,proto_base_data_type_pb.Value.deserializeBinaryFromReader);
+      msg.setValue(value);
       break;
     default:
       reader.skipField();
@@ -8804,6 +8810,14 @@ proto.data.GetDefaultValueRequest.serializeBinaryToWriter = function(message, wr
       6,
       f,
       proto_base_data_type_pb.KeyValue.serializeBinaryToWriter
+    );
+  }
+  f = message.getValue();
+  if (f != null) {
+    writer.writeMessage(
+      7,
+      f,
+      proto_base_data_type_pb.Value.serializeBinaryToWriter
     );
   }
 };
@@ -8953,6 +8967,43 @@ proto.data.GetDefaultValueRequest.prototype.addContextAttributes = function(opt_
  */
 proto.data.GetDefaultValueRequest.prototype.clearContextAttributesList = function() {
   return this.setContextAttributesList([]);
+};
+
+
+/**
+ * optional Value value = 7;
+ * @return {?proto.data.Value}
+ */
+proto.data.GetDefaultValueRequest.prototype.getValue = function() {
+  return /** @type{?proto.data.Value} */ (
+    jspb.Message.getWrapperField(this, proto_base_data_type_pb.Value, 7));
+};
+
+
+/**
+ * @param {?proto.data.Value|undefined} value
+ * @return {!proto.data.GetDefaultValueRequest} returns this
+*/
+proto.data.GetDefaultValueRequest.prototype.setValue = function(value) {
+  return jspb.Message.setWrapperField(this, 7, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.data.GetDefaultValueRequest} returns this
+ */
+proto.data.GetDefaultValueRequest.prototype.clearValue = function() {
+  return this.setValue(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.data.GetDefaultValueRequest.prototype.hasValue = function() {
+  return jspb.Message.getField(this, 7) != null;
 };
 
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature


#### Steps to reproduce

1. Expand `Open Item` menu.
2. Open `Generate Payment Selection (From Invoice)`

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/171664982-fc60601b-e071-49bc-afac-e27ea06972d6.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/171664987-528f88f5-7548-406a-ac84-7616ff511702.mp4

#### Expected behavior
In the backend it was looking for the default value of the `Bank Account` field, but since it was not in the dictionary definition it returned empty values.

In the context of the session we have the value in the `Bank Account` field, so it should be automatically set, overwriting the possible default value in case of having it.

Also, when changing the value of this field, all the fields that are dependent on it, such as the `Currency` and `Current Balance` fields, must change or clear their values.

#### Other relevant information
- Your OS: Linux Mint 20.3 x64.
- Web Browser: Mozilla Firefox 99.0
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/11 https://github.com/solop-develop/frontend-core/issues/67 https://github.com/solop-develop/frontend-core/issues/98 https://github.com/solop-develop/frontend-core/issues/140

