### PR TITLE
fix: TimeControl Confirmed optional flag.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adempiere/grpc-api",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "ADempiere Web Store write in Javascript for a node service",
   "author": "Yamel Senih",
   "contributors": [

--- a/proto/time_control.proto
+++ b/proto/time_control.proto
@@ -58,7 +58,7 @@ message ListResourcesAssignmentRequest {
 	string resource_type_uuid = 5;
 	string name = 6;
 	string description = 7;
-	bool is_only_confirmed = 8;
+	string confirmed = 8;
 	bool is_waiting_for_ordered = 9;
 	int64 date_from = 10;
 	int64 date_to = 11;

--- a/src/grpc/proto/time_control_pb.js
+++ b/src/grpc/proto/time_control_pb.js
@@ -529,7 +529,7 @@ proto.time_control.ListResourcesAssignmentRequest.toObject = function(includeIns
     resourceTypeUuid: jspb.Message.getFieldWithDefault(msg, 5, ""),
     name: jspb.Message.getFieldWithDefault(msg, 6, ""),
     description: jspb.Message.getFieldWithDefault(msg, 7, ""),
-    isOnlyConfirmed: jspb.Message.getBooleanFieldWithDefault(msg, 8, false),
+    confirmed: jspb.Message.getFieldWithDefault(msg, 8, ""),
     isWaitingForOrdered: jspb.Message.getBooleanFieldWithDefault(msg, 9, false),
     dateFrom: jspb.Message.getFieldWithDefault(msg, 10, 0),
     dateTo: jspb.Message.getFieldWithDefault(msg, 11, 0)
@@ -599,8 +599,8 @@ proto.time_control.ListResourcesAssignmentRequest.deserializeBinaryFromReader = 
       msg.setDescription(value);
       break;
     case 8:
-      var value = /** @type {boolean} */ (reader.readBool());
-      msg.setIsOnlyConfirmed(value);
+      var value = /** @type {string} */ (reader.readString());
+      msg.setConfirmed(value);
       break;
     case 9:
       var value = /** @type {boolean} */ (reader.readBool());
@@ -693,9 +693,9 @@ proto.time_control.ListResourcesAssignmentRequest.serializeBinaryToWriter = func
       f
     );
   }
-  f = message.getIsOnlyConfirmed();
-  if (f) {
-    writer.writeBool(
+  f = message.getConfirmed();
+  if (f.length > 0) {
+    writer.writeString(
       8,
       f
     );
@@ -870,20 +870,20 @@ proto.time_control.ListResourcesAssignmentRequest.prototype.setDescription = fun
 
 
 /**
- * optional bool is_only_confirmed = 8;
- * @return {boolean}
+ * optional string confirmed = 8;
+ * @return {string}
  */
-proto.time_control.ListResourcesAssignmentRequest.prototype.getIsOnlyConfirmed = function() {
-  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 8, false));
+proto.time_control.ListResourcesAssignmentRequest.prototype.getConfirmed = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 8, ""));
 };
 
 
 /**
- * @param {boolean} value
+ * @param {string} value
  * @return {!proto.time_control.ListResourcesAssignmentRequest} returns this
  */
-proto.time_control.ListResourcesAssignmentRequest.prototype.setIsOnlyConfirmed = function(value) {
-  return jspb.Message.setProto3BooleanField(this, 8, value);
+proto.time_control.ListResourcesAssignmentRequest.prototype.setConfirmed = function(value) {
+  return jspb.Message.setProto3StringField(this, 8, value);
 };
 
 

--- a/src/services/timeControl.js
+++ b/src/services/timeControl.js
@@ -88,7 +88,7 @@ class TimeControl {
     resourceTypeUuid,
     name,
     description,
-    isOnlyConfirmed = false,
+    confirmed,
     isWaitingForOrdered = false,
     dateFrom,
     dateTo,
@@ -109,7 +109,7 @@ class TimeControl {
     request.setResourceTypeUuid(resourceTypeUuid);
     request.setName(name);
     request.setDescription(description);
-    request.setIsOnlyConfirmed(isOnlyConfirmed);
+    request.setConfirmed(confirmed);
     request.setIsWaitingForOrdered(isWaitingForOrdered);
     request.setDateFrom(dateFrom);
     request.setDateTo(dateTo);


### PR DESCRIPTION
Now you can list confirmed records, unconfirmed records, and both, previously the search was exclusive.


https://user-images.githubusercontent.com/20288327/195099025-4c4c5377-a43e-4b89-9ee7-9edf02e30219.mp4

