### PR TITLE
fix: Search text with like as default operator.

### DIFF
--- a/lib/convertEnums.js
+++ b/lib/convertEnums.js
@@ -56,36 +56,6 @@ const convertEnums = {
   },
 
   /**
-   * Get all operator or get key value type from value
-   * @param {string} key
-   * @param {number} value
-   * @returns {number|string|object}
-      EQUAL = 0;
-      NOT_EQUAL = 1;
-      LIKE = 2;
-      NOT_LIKE = 3;
-      GREATER = 4;
-      GREATER_EQUAL = 5;
-      LESS = 6;
-      LESS_EQUAL = 7;
-      BETWEEN = 8;
-      NOT_NULL = 9;
-      NULL = 10;
-      IN = 11;
-      NOT_IN = 12;
-   */
-  getCondition_Operator({ key, value }) {
-    const { Condition } = require('@adempiere/grpc-api/src/grpc/proto/base_data_type_pb.js');
-    const { Operator } = Condition;
-
-    return convertEnums.getValueOrKey({
-      list: Operator,
-      key,
-      value
-    });
-  },
-
-  /**
    * @param {number} value
    * @param {string} key
    * @returns {number|string|object}

--- a/lib/convertValues.js
+++ b/lib/convertValues.js
@@ -417,52 +417,6 @@
   },
 
   /**
-   * Convert a parameter defined by columnName and value to Value Object
-   * @param {string} columnName
-   * @param {mixed}  value
-   * @param {mixed}  valueTo
-   * @param {array}  values
-   * @returns Object
-   */
-  convertConditionToGRPC({ columnName, value, valueTo, values = [], operator = 'EQUAL' }) {
-    const { Condition } = require('@adempiere/grpc-api/src/grpc/proto/base_data_type_pb.js');
-    const { Operator } = Condition;
-    const conditionInstance = new Condition();
-    conditionInstance.setColumnName(columnName);
-
-    // set operator
-    conditionInstance.setOperator(Operator.EQUAL); // 0
-    if (operator) {
-      conditionInstance.setOperator(Operator[operator]);
-    }
-
-    // set value and value to
-    if (!convertValues.isEmptyValue(value)) {
-      conditionInstance.setValue(
-        convertValues.convertValueToGRPC({ value })
-      );
-    }
-    if (!convertValues.isEmptyValue(valueTo)) {
-      conditionInstance.setValueTo(
-        convertValues.convertValueToGRPC({
-          value: valueTo
-        })
-      );
-    }
-    // set values
-    if (!convertValues.isEmptyValue(values)) {
-      values.forEach(itemValue => {
-        const convertedValue = convertValues.convertValueToGRPC({
-          value: itemValue
-        });
-        conditionInstance.addValues(convertedValue);
-      });
-    }
-    //  Return converted condition
-    return conditionInstance;
-  },
-
-  /**
    * Get order by property converted to gRPC
    * @param {string} columnName
    * @param {string} orderType 'ASCENDING' or 'DESCENDING'
@@ -545,6 +499,7 @@
         filters = JSON.parse(filters);
       }
 
+      const { convertConditionToGRPC } = require('@adempiere/grpc-api/src/utils/baseDataTypeToGRPC.js');
       filters.forEach(condition => {
         let parsedCondition = condition;
         // set with get method is string value
@@ -552,7 +507,7 @@
           parsedCondition = JSON.parse(condition);
         }
 
-        const criteriaGrpc = convertValues.convertConditionToGRPC({
+        const criteriaGrpc = convertConditionToGRPC({
           columnName: parsedCondition.column_name,
           value: parsedCondition.value,
           valueTo: parsedCondition.value_to,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adempiere/grpc-api",
-  "version": "3.6.1",
-  "description": "ADempiere Web Store write in Javascript for a node service",
+  "version": "3.6.2",
+  "description": "ADempiere Web write in Javascript for a node service",
   "author": "Yamel Senih",
   "contributors": [
     {

--- a/proto/base_data_type.proto
+++ b/proto/base_data_type.proto
@@ -117,19 +117,20 @@ message Condition {
 	Value value_to = 3;
 	repeated Value values = 4;
 	enum Operator {
-		EQUAL = 0;
-		NOT_EQUAL = 1;
-		LIKE = 2;
-		NOT_LIKE = 3;
-		GREATER = 4;
-		GREATER_EQUAL = 5;
-		LESS = 6;
-		LESS_EQUAL = 7;
-		BETWEEN = 8;
-		NOT_NULL = 9;
-		NULL = 10;
-		IN = 11;
-		NOT_IN = 12;
+		VOID = 0;
+		EQUAL = 1;
+		NOT_EQUAL = 2;
+		LIKE = 3;
+		NOT_LIKE = 4;
+		GREATER = 5;
+		GREATER_EQUAL = 6;
+		LESS = 7;
+		LESS_EQUAL = 8;
+		BETWEEN = 9;
+		NOT_NULL = 10;
+		NULL = 11;
+		IN = 12;
+		NOT_IN = 13;
 	}
 	//	Operators
 	Operator operator = 5;

--- a/src/grpc/proto/base_data_type_pb.js
+++ b/src/grpc/proto/base_data_type_pb.js
@@ -3056,19 +3056,20 @@ proto.data.Condition.serializeBinaryToWriter = function(message, writer) {
  * @enum {number}
  */
 proto.data.Condition.Operator = {
-  EQUAL: 0,
-  NOT_EQUAL: 1,
-  LIKE: 2,
-  NOT_LIKE: 3,
-  GREATER: 4,
-  GREATER_EQUAL: 5,
-  LESS: 6,
-  LESS_EQUAL: 7,
-  BETWEEN: 8,
-  NOT_NULL: 9,
-  NULL: 10,
-  IN: 11,
-  NOT_IN: 12
+  VOID: 0,
+  EQUAL: 1,
+  NOT_EQUAL: 2,
+  LIKE: 3,
+  NOT_LIKE: 4,
+  GREATER: 5,
+  GREATER_EQUAL: 6,
+  LESS: 7,
+  LESS_EQUAL: 8,
+  BETWEEN: 9,
+  NOT_NULL: 10,
+  NULL: 11,
+  IN: 12,
+  NOT_IN: 13
 };
 
 /**

--- a/src/utils/baseDataTypeFromGRPC.js
+++ b/src/utils/baseDataTypeFromGRPC.js
@@ -1,0 +1,52 @@
+/*************************************************************************************
+ * Product: ADempiere gRPC Business Data Client Convert Utils                        *
+ * Copyright (C) 2012-2020 E.R.P. Consultores y Asociados, C.A.                      *
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com                      *
+ * This program is free software: you can redistribute it and/or modify              *
+ * it under the terms of the GNU General Public License as published by              *
+ * the Free Software Foundation, either version 3 of the License, or                 *
+ * (at your option) any later version.                                               *
+ * This program is distributed in the hope that it will be useful,                   *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                    *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                     *
+ * GNU General Public License for more details.                                      *
+ * You should have received a copy of the GNU General Public License                 *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.             *
+ ************************************************************************************/
+
+const baseDataTypeFromGRPC = {
+
+  /**
+   * Get all operator or get key value type from value
+   * @param {string} key
+   * @param {number} value
+   * @returns {number|string|object}
+      VOID = 0;
+      EQUAL = 1;
+      NOT_EQUAL = 2;
+      LIKE = 3;
+      NOT_LIKE = 4;
+      GREATER = 5;
+      GREATER_EQUAL = 6;
+      LESS = 7;
+      LESS_EQUAL = 8;
+      BETWEEN = 9;
+      NOT_NULL = 10;
+      NULL = 11;
+      IN = 12;
+      NOT_IN = 13;
+   */
+  getCondition_Operator({ key, value }) {
+    const { getValueOrKey } = require('@adempiere/grpc-api/src/utils/convertEnums.js')
+    const { Condition } = require('@adempiere/grpc-api/src/grpc/proto/base_data_type_pb.js');
+    const { Operator } = Condition;
+
+    return getValueOrKey({
+      list: Operator,
+      key,
+      value
+    });
+  }
+}
+
+module.exports = baseDataTypeFromGRPC;

--- a/src/utils/baseDataTypeToGRPC.js
+++ b/src/utils/baseDataTypeToGRPC.js
@@ -1,0 +1,68 @@
+/*************************************************************************************
+ * Product: ADempiere gRPC Business Data Client Convert Utils                        *
+ * Copyright (C) 2012-2020 E.R.P. Consultores y Asociados, C.A.                      *
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com                      *
+ * This program is free software: you can redistribute it and/or modify              *
+ * it under the terms of the GNU General Public License as published by              *
+ * the Free Software Foundation, either version 3 of the License, or                 *
+ * (at your option) any later version.                                               *
+ * This program is distributed in the hope that it will be useful,                   *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                    *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                     *
+ * GNU General Public License for more details.                                      *
+ * You should have received a copy of the GNU General Public License                 *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.             *
+ ************************************************************************************/
+
+const baseDataTypeToGRPC = {
+
+  /**
+   * Convert a parameter defined by columnName and value to Value Object
+   * @param {string} columnName
+   * @param {mixed}  value
+   * @param {mixed}  valueTo
+   * @param {array}  values
+   * @param {string} operator
+   * @returns Object
+   */
+   convertConditionToGRPC({ columnName, value, valueTo, values = [], operator = 'VOID' }) {
+    const { isEmptyValue, convertValueToGRPC } = require('@adempiere/grpc-api/lib/convertValues.js');
+    const { Condition } = require('@adempiere/grpc-api/src/grpc/proto/base_data_type_pb.js');
+    const { Operator } = Condition;
+    const conditionInstance = new Condition();
+    conditionInstance.setColumnName(columnName);
+
+    // set operator
+    conditionInstance.setOperator(Operator.VOID); // 0
+    if (operator) {
+      conditionInstance.setOperator(Operator[operator]);
+    }
+
+    // set value and value to
+    if (!isEmptyValue(value)) {
+      conditionInstance.setValue(
+        convertValueToGRPC({ value })
+      );
+    }
+    if (!isEmptyValue(valueTo)) {
+      conditionInstance.setValueTo(
+        convertValueToGRPC({
+          value: valueTo
+        })
+      );
+    }
+    // set values
+    if (!isEmptyValue(values)) {
+      values.forEach(itemValue => {
+        const convertedValue = convertValueToGRPC({
+          value: itemValue
+        });
+        conditionInstance.addValues(convertedValue);
+      });
+    }
+    //  Return converted condition
+    return conditionInstance;
+  },
+}
+
+module.exports = baseDataTypeToGRPC;

--- a/src/utils/convertEnums.js
+++ b/src/utils/convertEnums.js
@@ -1,0 +1,37 @@
+/*************************************************************************************
+ * Product: ADempiere gRPC Business Data Client Convert Utils                        *
+ * Copyright (C) 2012-2020 E.R.P. Consultores y Asociados, C.A.                      *
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com                      *
+ * This program is free software: you can redistribute it and/or modify              *
+ * it under the terms of the GNU General Public License as published by              *
+ * the Free Software Foundation, either version 3 of the License, or                 *
+ * (at your option) any later version.                                               *
+ * This program is distributed in the hope that it will be useful,                   *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                    *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                     *
+ * GNU General Public License for more details.                                      *
+ * You should have received a copy of the GNU General Public License                 *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.             *
+ ************************************************************************************/
+
+const convertEnums = {
+
+  /**
+   * Get all values type or get key value type from value
+   * @param {object} list
+   * @param {string} key
+   * @param {number} value
+   * @returns {number|string|object}
+   */
+  getValueOrKey({ list, key, value }) {
+    if (key !== undefined) {
+      return list[key];
+    } else if (value !== undefined) {
+      return Object.keys(list).find(keyItem => list[keyItem] === value);
+    }
+    // return all values
+    return list;
+  }
+}
+
+module.exports = convertEnums;


### PR DESCRIPTION
When a search is made for a text field and the LIKE operator was not sent, it takes EQUAL as the default operator, so an exact search had to be made.

A default operator called VOID is added, which when set, searches for the default operator according to the display type, for number type fields the EQUAL, for text type fields the LIKE operator.


#### Screenshot

https://user-images.githubusercontent.com/20288327/201457227-3583d223-1404-4c01-8f82-6983d72d3658.mp4



#### Additional context
Fixes https://github.com/solop-develop/frontend-core/issues/462
Depends on https://github.com/solop-develop/backend/pull/149