### PR TITLE
fix: Objectiv-C class prefix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adempiere/grpc-api",
-  "version": "3.9.8",
+  "version": "3.9.9",
   "description": "ADempiere Web write in Javascript for a node service",
   "author": "Yamel Senih",
   "contributors": [

--- a/proto/access.proto
+++ b/proto/access.proto
@@ -7,17 +7,16 @@
  * (at your option) any later version.                                               *
  * This program is distributed in the hope that it will be useful,                   *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                    *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                      *
  * GNU General Public License for more details.                                      *
  * You should have received a copy of the GNU General Public License                 *
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.            *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.             *
  ************************************************************************************/
 syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "org.spin.backend.grpc.access";
 option java_outer_classname = "ADempiereAccess";
-option objc_class_prefix = "HLW";
 
 package access;
 

--- a/proto/base_data_type.proto
+++ b/proto/base_data_type.proto
@@ -7,7 +7,7 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.            *

--- a/proto/business_partner.proto
+++ b/proto/business_partner.proto
@@ -7,10 +7,10 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
- * along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
  ************************************************************************************/
 syntax = "proto3";
 
@@ -18,7 +18,6 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.spin.backend.grpc.bpartner";
 option java_outer_classname = "ADempiereBusinessPartner";
-option objc_class_prefix = "HLW";
 
 import "proto/base_data_type.proto";
 import "proto/client.proto";

--- a/proto/client.proto
+++ b/proto/client.proto
@@ -7,17 +7,16 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
- * along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
  ************************************************************************************/
 syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "org.spin.backend.grpc.client";
 option java_outer_classname = "ADempiereClient";
-option objc_class_prefix = "HLW";
 
 package data;
 

--- a/proto/core_functionality.proto
+++ b/proto/core_functionality.proto
@@ -7,17 +7,16 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
- * along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
  ************************************************************************************/
 syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "org.spin.backend.grpc.common";
 option java_outer_classname = "ADempiereCoreFunctionality";
-option objc_class_prefix = "HLW";
 
 import "proto/base_data_type.proto";
 import "proto/client.proto";

--- a/proto/dictionary.proto
+++ b/proto/dictionary.proto
@@ -7,17 +7,16 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
- * along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
  ************************************************************************************/
 syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "org.spin.backend.grpc.dictionary";
 option java_outer_classname = "ADempiereDictionary";
-option objc_class_prefix = "HLW";
 
 package dictionary;
 

--- a/proto/enrollment.proto
+++ b/proto/enrollment.proto
@@ -7,17 +7,16 @@
  * (at your option) any later version.                                               *
  * This program is distributed in the hope that it will be useful,                   *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                    *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                      *
  * GNU General Public License for more details.                                      *
  * You should have received a copy of the GNU General Public License                 *
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.            *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.             *
  ************************************************************************************/
 syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "org.spin.backend.grpc.enrollment";
 option java_outer_classname = "Enrollment";
-option objc_class_prefix = "HLW";
 
 package enrollment;
 

--- a/proto/file_management.proto
+++ b/proto/file_management.proto
@@ -7,7 +7,7 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.            *

--- a/proto/general_ledger.proto
+++ b/proto/general_ledger.proto
@@ -7,7 +7,7 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.            *

--- a/proto/in_out.proto
+++ b/proto/in_out.proto
@@ -7,10 +7,10 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
- * along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
  ************************************************************************************/
 syntax = "proto3";
 
@@ -18,7 +18,6 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.spin.backend.grpc.inout";
 option java_outer_classname = "ADempiereInOut";
-option objc_class_prefix = "HLW";
 
 import "proto/base_data_type.proto";
 import "proto/client.proto";

--- a/proto/invoice.proto
+++ b/proto/invoice.proto
@@ -7,10 +7,10 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
- * along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
  ************************************************************************************/
 syntax = "proto3";
 
@@ -18,7 +18,6 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.spin.backend.grpc.invoice";
 option java_outer_classname = "ADempiereInvoice";
-option objc_class_prefix = "HLW";
 
 import "proto/base_data_type.proto";
 import "proto/client.proto";

--- a/proto/material_management.proto
+++ b/proto/material_management.proto
@@ -7,7 +7,7 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.            *

--- a/proto/order.proto
+++ b/proto/order.proto
@@ -7,10 +7,10 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
- * along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
  ************************************************************************************/
 syntax = "proto3";
 
@@ -18,7 +18,6 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.spin.backend.grpc.order";
 option java_outer_classname = "ADempiereOrder";
-option objc_class_prefix = "HLW";
 
 import "proto/base_data_type.proto";
 import "proto/client.proto";

--- a/proto/payment.proto
+++ b/proto/payment.proto
@@ -7,10 +7,10 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
- * along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
  ************************************************************************************/
 syntax = "proto3";
 
@@ -18,7 +18,6 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.spin.backend.grpc.payment";
 option java_outer_classname = "ADempierePayment";
-option objc_class_prefix = "HLW";
 
 import "proto/base_data_type.proto";
 import "proto/client.proto";

--- a/proto/payment_print_export.proto
+++ b/proto/payment_print_export.proto
@@ -7,7 +7,7 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.            *

--- a/proto/payroll_action_notice.proto
+++ b/proto/payroll_action_notice.proto
@@ -7,7 +7,7 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
@@ -18,7 +18,6 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.spin.backend.grpc.form";
 option java_outer_classname = "ADempierePayrollActionNotice";
-option objc_class_prefix = "HLW";
 
 import "proto/base_data_type.proto";
 import "proto/client.proto";

--- a/proto/point_of_sales.proto
+++ b/proto/point_of_sales.proto
@@ -7,7 +7,7 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.            *

--- a/proto/product.proto
+++ b/proto/product.proto
@@ -7,10 +7,10 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
- * along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
  ************************************************************************************/
 syntax = "proto3";
 
@@ -18,7 +18,6 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.spin.backend.grpc.product";
 option java_outer_classname = "ADempiereProduct";
-option objc_class_prefix = "HLW";
 
 import "proto/base_data_type.proto";
 import "proto/client.proto";

--- a/proto/time_control.proto
+++ b/proto/time_control.proto
@@ -7,7 +7,7 @@
  * (at your option) any later version.                                              *
  * This program is distributed in the hope that it will be useful,                  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
  * GNU General Public License for more details.                                     *
  * You should have received a copy of the GNU General Public License                *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.            *

--- a/src/grpc/proto/access_grpc_pb.js
+++ b/src/grpc/proto/access_grpc_pb.js
@@ -10,10 +10,10 @@
 // (at your option) any later version.                                               *
 // This program is distributed in the hope that it will be useful,                   *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                    *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                      *
 // GNU General Public License for more details.                                      *
 // You should have received a copy of the GNU General Public License                 *
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.            *
+// along with this program. If not, see <https://www.gnu.org/licenses/>.             *
 // **********************************************************************************
 'use strict';
 var grpc = require('@grpc/grpc-js');

--- a/src/grpc/proto/business_partner_grpc_pb.js
+++ b/src/grpc/proto/business_partner_grpc_pb.js
@@ -10,10 +10,10 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
-// along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+// along with this program. If not, see <https://www.gnu.org/licenses/>.            *
 // **********************************************************************************
 'use strict';
 var grpc = require('@grpc/grpc-js');

--- a/src/grpc/proto/core_functionality_grpc_pb.js
+++ b/src/grpc/proto/core_functionality_grpc_pb.js
@@ -10,10 +10,10 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
-// along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+// along with this program. If not, see <https://www.gnu.org/licenses/>.            *
 // **********************************************************************************
 'use strict';
 var grpc = require('@grpc/grpc-js');

--- a/src/grpc/proto/dictionary_grpc_pb.js
+++ b/src/grpc/proto/dictionary_grpc_pb.js
@@ -10,10 +10,10 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
-// along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+// along with this program. If not, see <https://www.gnu.org/licenses/>.            *
 // **********************************************************************************
 'use strict';
 var grpc = require('@grpc/grpc-js');

--- a/src/grpc/proto/enrollment_grpc_pb.js
+++ b/src/grpc/proto/enrollment_grpc_pb.js
@@ -10,10 +10,10 @@
 // (at your option) any later version.                                               *
 // This program is distributed in the hope that it will be useful,                   *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                    *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                      *
 // GNU General Public License for more details.                                      *
 // You should have received a copy of the GNU General Public License                 *
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.            *
+// along with this program. If not, see <https://www.gnu.org/licenses/>.             *
 // **********************************************************************************
 'use strict';
 var grpc = require('@grpc/grpc-js');

--- a/src/grpc/proto/file_management_grpc_pb.js
+++ b/src/grpc/proto/file_management_grpc_pb.js
@@ -10,7 +10,7 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
 // along with this program. If not, see <https://www.gnu.org/licenses/>.            *

--- a/src/grpc/proto/general_ledger_grpc_pb.js
+++ b/src/grpc/proto/general_ledger_grpc_pb.js
@@ -10,7 +10,7 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
 // along with this program. If not, see <https://www.gnu.org/licenses/>.            *

--- a/src/grpc/proto/in_out_grpc_pb.js
+++ b/src/grpc/proto/in_out_grpc_pb.js
@@ -10,10 +10,10 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
-// along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+// along with this program. If not, see <https://www.gnu.org/licenses/>.            *
 // **********************************************************************************
 'use strict';
 var grpc = require('@grpc/grpc-js');

--- a/src/grpc/proto/invoice_grpc_pb.js
+++ b/src/grpc/proto/invoice_grpc_pb.js
@@ -10,10 +10,10 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
-// along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+// along with this program. If not, see <https://www.gnu.org/licenses/>.            *
 // **********************************************************************************
 'use strict';
 var grpc = require('@grpc/grpc-js');

--- a/src/grpc/proto/material_management_grpc_pb.js
+++ b/src/grpc/proto/material_management_grpc_pb.js
@@ -10,7 +10,7 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
 // along with this program. If not, see <https://www.gnu.org/licenses/>.            *

--- a/src/grpc/proto/order_grpc_pb.js
+++ b/src/grpc/proto/order_grpc_pb.js
@@ -10,10 +10,10 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
-// along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+// along with this program. If not, see <https://www.gnu.org/licenses/>.            *
 // **********************************************************************************
 'use strict';
 var grpc = require('@grpc/grpc-js');

--- a/src/grpc/proto/payment_grpc_pb.js
+++ b/src/grpc/proto/payment_grpc_pb.js
@@ -10,10 +10,10 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
-// along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+// along with this program. If not, see <https://www.gnu.org/licenses/>.            *
 // **********************************************************************************
 'use strict';
 var grpc = require('@grpc/grpc-js');

--- a/src/grpc/proto/payment_print_export_grpc_pb.js
+++ b/src/grpc/proto/payment_print_export_grpc_pb.js
@@ -10,7 +10,7 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
 // along with this program. If not, see <https://www.gnu.org/licenses/>.            *

--- a/src/grpc/proto/payroll_action_notice_grpc_pb.js
+++ b/src/grpc/proto/payroll_action_notice_grpc_pb.js
@@ -10,7 +10,7 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
 // along with this program. If not, see <https://www.gnu.org/licenses/>.            *

--- a/src/grpc/proto/point_of_sales_grpc_pb.js
+++ b/src/grpc/proto/point_of_sales_grpc_pb.js
@@ -10,7 +10,7 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
 // along with this program. If not, see <https://www.gnu.org/licenses/>.            *

--- a/src/grpc/proto/product_grpc_pb.js
+++ b/src/grpc/proto/product_grpc_pb.js
@@ -10,10 +10,10 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
-// along with this program.	If not, see <https://www.gnu.org/licenses/>.            *
+// along with this program. If not, see <https://www.gnu.org/licenses/>.            *
 // **********************************************************************************
 'use strict';
 var grpc = require('@grpc/grpc-js');

--- a/src/grpc/proto/time_control_grpc_pb.js
+++ b/src/grpc/proto/time_control_grpc_pb.js
@@ -10,7 +10,7 @@
 // (at your option) any later version.                                              *
 // This program is distributed in the hope that it will be useful,                  *
 // but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the                     *
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
 // GNU General Public License for more details.                                     *
 // You should have received a copy of the GNU General Public License                *
 // along with this program. If not, see <https://www.gnu.org/licenses/>.            *


### PR DESCRIPTION
- Remove `option objc_class_prefix = "HLW";` from `.proto` files.

fixes https://github.com/solop-develop/backend/issues/216
