### PR TITLE
fix: Callout empty context values.

### DIFF
--- a/lib/convertBaseDataType.js
+++ b/lib/convertBaseDataType.js
@@ -1,6 +1,6 @@
 /*************************************************************************************
  * Product: ADempiere gRPC Base Data Type Client Convert Utils                       *
- * Copyright (C) 2012-2023 E.R.P. Consultores y Asociados, C.A.                      *
+ * Copyright (C) 2018-2023 E.R.P. Consultores y Asociados, C.A.                      *
  * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com                      *
  * This program is free software: you can redistribute it and/or modify              *
  * it under the terms of the GNU General Public License as published by              *
@@ -8,7 +8,7 @@
  * (at your option) any later version.                                               *
  * This program is distributed in the hope that it will be useful,                   *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                    *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                      *
  * GNU General Public License for more details.                                      *
  * You should have received a copy of the GNU General Public License                 *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.             *
@@ -106,14 +106,15 @@
   convertAttributes (context) {
     const { getValueFromGRPC } = require('@adempiere/grpc-api/src/utils/baseDataTypeFromGRPC.js');
 
-    let values = []
-    context.forEach((value, key) => {
-      values.push({
+    const values = context.forEach((value, key) => {
+      const convertedValue = getValueFromGRPC(value);
+      const currentValue = isEmptyValue(convertedValue) ? null : convertedValue;
+      return {
         key: key,
-        value: getValueFromGRPC(value)
-      })
+        value: currentValue
+      };
     })
-    return values
+    return values;
   },
 
   convertProcessLogFromGRPC(processLog) {

--- a/src/utils/baseDataTypeFromGRPC.js
+++ b/src/utils/baseDataTypeFromGRPC.js
@@ -1,6 +1,6 @@
 /*************************************************************************************
  * Product: ADempiere gRPC Base Data Type Client Convert Utils                       *
- * Copyright (C) 2012-2023 E.R.P. Consultores y Asociados, C.A.                      *
+ * Copyright (C) 2018-2023 E.R.P. Consultores y Asociados, C.A.                      *
  * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com                      *
  * This program is free software: you can redistribute it and/or modify              *
  * it under the terms of the GNU General Public License as published by              *
@@ -8,7 +8,7 @@
  * (at your option) any later version.                                               *
  * This program is distributed in the hope that it will be useful,                   *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of                    *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                      *
  * GNU General Public License for more details.                                      *
  * You should have received a copy of the GNU General Public License                 *
  * along with this program. If not, see <https://www.gnu.org/licenses/>.             *
@@ -154,7 +154,7 @@ function getValueFromGRPC(valueToConvert) {
       returnValue = undefined;
       break;
   }
-  return returnValue; 
+  return returnValue;
 }
 
 /**

--- a/src/utils/valueUtils.js
+++ b/src/utils/valueUtils.js
@@ -1,6 +1,6 @@
 /*************************************************************************************
  * Product: ADempiere gRPC Value Utils                                               *
- * Copyright (C) 2012-2020 E.R.P. Consultores y Asociados, C.A.                      *
+ * Copyright (C) 2018-2023 E.R.P. Consultores y Asociados, C.A.                      *
  * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com                      *
  * This program is free software: you can redistribute it and/or modify              *
  * it under the terms of the GNU General Public License as published by              *

--- a/src/utils/valueUtilsFromGRPC.js
+++ b/src/utils/valueUtilsFromGRPC.js
@@ -1,6 +1,6 @@
 /*************************************************************************************
  * Product: ADempiere gRPC General Value Utils Convert                               *
- * Copyright (C) 2012-2023 E.R.P. Consultores y Asociados, C.A.                      *
+ * Copyright (C) 2018-2023 E.R.P. Consultores y Asociados, C.A.                      *
  * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com                      *
  * This program is free software: you can redistribute it and/or modify              *
  * it under the terms of the GNU General Public License as published by              *
@@ -24,12 +24,15 @@
 function getValuesMapFromGRPC({ mapToConvert, returnType = 'map', keyName = 'key', valueName = 'value' }) {
   let returnValues;
   const { getValueFromGRPC } = require('@adempiere/grpc-api/src/utils/baseDataTypeFromGRPC.js');
+  const { isEmptyValue } = require('@adempiere/grpc-api/src/utils/valueUtils.js');
 
   switch (returnType) {
     case 'object':
       returnValues = {};
       mapToConvert.forEach((value, key) => {
-        returnValues[key] = getValueFromGRPC(value);
+        const convertedValue = getValueFromGRPC(value);
+        const currentValue = isEmptyValue(convertedValue) ? null : convertedValue;
+        returnValues[key] = currentValue;
       });
       break;
 
@@ -37,8 +40,12 @@ function getValuesMapFromGRPC({ mapToConvert, returnType = 'map', keyName = 'key
       returnValues = [];
       mapToConvert.forEach((value, key) => {
         const item = {}
+        const convertedValue = getValueFromGRPC(value);
+        const currentValue = isEmptyValue(convertedValue) ? null : convertedValue;
+
         item[keyName] = key;
-        item[valueName] = getValueFromGRPC(value);
+        item[valueName] = currentValue;
+
         returnValues.push(item);
       });
       break;
@@ -47,7 +54,9 @@ function getValuesMapFromGRPC({ mapToConvert, returnType = 'map', keyName = 'key
     case 'map':
       returnValues = new Map();
       mapToConvert.forEach((value, key) => {
-        returnValues.set(key, getValueFromGRPC(value));
+        const convertedValue = getValueFromGRPC(value);
+        const currentValue = isEmptyValue(convertedValue) ? null : convertedValue;
+        returnValues.set(key, currentValue);
       });
       break;
   }


### PR DESCRIPTION
If the column that triggers the callout is `C_BPartner_ID`, whose value is 10000, but it is sent in the context attributes `C_BPartner_ID = 5000`, in the return context it will still have the value 5000 when it should be 1000.

It also does not take into account the context that is emptied, which may be necessary for fields that depend on another for their value such as `C_BPartner_Location_ID`.

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/636
