### PR TITLE
fix: Convert resource reference.

### DIFF
--- a/lib/convertBaseDataType.js
+++ b/lib/convertBaseDataType.js
@@ -282,42 +282,45 @@
   },
 
   convertResourceFromGRPC(resourceToConvert) {
-    if (resourceToConvert) {
-      return resourceToConvert.getData();
+    if (!resourceToConvert) {
+      return undefined;
     }
-    return undefined;
+    return resourceToConvert.getData();
   },
 
   convertAttachmentFromGRPC(attachmentToConvert) {
-    if (attachmentToConvert) {
-      return {
-        attachment_uuid: attachmentToConvert.getAttachmentUuid(),
-        title: attachmentToConvert.getTitle(),
-        text_msg: attachmentToConvert.getTextMsg(),
-        resource_references_list: attachmentToConvert.getResourceReferencesList().map(itemResourceReference => {
-          return convertBaseDataType.convertResourceReferenceFromGRPC(
-            itemResourceReference
-          );
-        })
-      };
+    if (!attachmentToConvert) {
+      return undefined;
     }
-    return undefined;
+  
+    return {
+      attachment_uuid: attachmentToConvert.getAttachmentUuid(),
+      title: attachmentToConvert.getTitle(),
+      text_msg: attachmentToConvert.getTextMsg(),
+      resource_references_list: attachmentToConvert.getResourceReferencesList().map(itemResourceReference => {
+        return convertBaseDataType.convertResourceReferenceFromGRPC(
+          itemResourceReference
+        );
+      })
+    };
   },
 
   convertResourceReferenceFromGRPC(resourceReferenceToConvert) {
-    if (resourceReferenceToConvert) {
-      return {
-        resource_uuid: resourceReferenceToConvert.getResourceUuid(),
-        file_name: resourceReferenceToConvert.getFileName(),
-        file_size: convertBaseDataType.getDecimalFromGRPC(
-          resourceReferenceToConvert.getFileSize()
-        ),
-        description: resourceReferenceToConvert.getDescription(),
-        text_msg: resourceReferenceToConvert.getTextMsg(),
-        content_type: resourceReferenceToConvert.getContentType()
-      }
+    if (!resourceReferenceToConvert) {
+      return undefined;
     }
-    return undefined;
+    const { getDecimalFromGRPC } = require('@adempiere/grpc-api/src/utils/baseDataTypeFromGRPC.js');
+
+    return {
+      resource_uuid: resourceReferenceToConvert.getResourceUuid(),
+      file_name: resourceReferenceToConvert.getFileName(),
+      file_size: getDecimalFromGRPC(
+        resourceReferenceToConvert.getFileSize()
+      ),
+      description: resourceReferenceToConvert.getDescription(),
+      text_msg: resourceReferenceToConvert.getTextMsg(),
+      content_type: resourceReferenceToConvert.getContentType()
+    };
   }
 
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adempiere/grpc-api",
-  "version": "4.5.7",
+  "version": "4.5.8",
   "description": "ADempiere Web write in Javascript for a node service",
   "author": "Yamel Senih",
   "contributors": [


### PR DESCRIPTION


#### Before this changes

![imagen](https://github.com/solop-develop/gRPC-API/assets/20288327/a7d14af8-9511-48d3-8fac-9598f8335d53)

```bash
error: uncaughtException: convertBaseDataType.getDecimalFromGRPC is not a function date=Thu Jul 13 2023 13:53:12 GMT-0400 (hora de Venezuela), pid=50187, uid=1000, gid=1000, cwd=/home/edwin/workspace/solop/proxy-adempiere-api, execPath=/home/edwin/.nvm/versions/node/v14.21.2/bin/node, version=v14.21.2, argv=[/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/.bin/ts-node, /home/edwin/workspace/solop/proxy-adempiere-api/src], rss=389304320, heapTotal=277286912, heapUsed=261712416, external=3318364, arrayBuffers=904393, loadavg=[1.23, 0.85, 0.76], uptime=14006.72, trace=[column=40, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/lib/convertBaseDataType.js, function=Object.convertResourceReferenceFromGRPC, line=312, method=convertResourceReferenceFromGRPC, native=false, column=38, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/lib/convertBaseDataType.js, function=null, line=298, method=null, native=false, column=null, file=null, function=Array.map, line=null, method=map, native=false, column=83, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/lib/convertBaseDataType.js, function=Object.convertAttachmentFromGRPC, line=297, method=convertAttachmentFromGRPC, native=false, column=21, file=/home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/user-interface/component/resource.ts, function=Object.callback, line=102, method=callback, native=false, column=28, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client.ts, function=Object.onReceiveStatus, line=352, method=onReceiveStatus, native=false, column=34, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts, function=Object.onReceiveStatus, line=455, method=onReceiveStatus, native=false, column=48, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts, function=Object.onReceiveStatus, line=417, method=onReceiveStatus, native=false, column=24, file=/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/resolving-call.ts, function=null, line=111, method=null, native=false, column=11, file=internal/process/task_queues.js, function=processTicksAndRejections, line=77, method=null, native=false], stack=[TypeError: convertBaseDataType.getDecimalFromGRPC is not a function,     at Object.convertResourceReferenceFromGRPC (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/lib/convertBaseDataType.js:312:40),     at /home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/lib/convertBaseDataType.js:298:38,     at Array.map (<anonymous>),     at Object.convertAttachmentFromGRPC (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/lib/convertBaseDataType.js:297:83),     at Object.callback (/home/edwin/workspace/solop/proxy-adempiere-api/src/modules/adempiere-api/api/extensions/adempiere/user-interface/component/resource.ts:102:21),     at Object.onReceiveStatus (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client.ts:352:28),     at Object.onReceiveStatus (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts:455:34),     at Object.onReceiveStatus (/home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/client-interceptors.ts:417:48),     at /home/edwin/workspace/solop/proxy-adempiere-api/node_modules/@adempiere/grpc-api/node_modules/@grpc/grpc-js/src/resolving-call.ts:111:24,     at processTicksAndRejections (internal/process/task_queues.js:77:11)]

```

#### After this changes

https://github.com/solop-develop/adempiere-grpc-server/assets/20288327/27ba4510-b4ff-4014-9799-42417e796219

```json
{
	"code": 200,
	"result": {
		"resource_uuid": "e49600f2-1e3e-4a62-9ce7-8a68bf2bdd2a",
		"file_name": "e49600f2-1e3e-4a62-9ce7-8a68bf2bdd2a-AccountingUS.csv",
		"file_size": 354,
		"description": "",
		"text_msg": "",
		"content_type": "text/csv"
	}
}
```
