### PR TITLE
fix: Timestamp with number as string value.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adempiere/grpc-api",
-  "version": "4.7.7",
+  "version": "4.7.8",
   "description": "ADempiere Web write in Javascript for a node service",
   "author": "Yamel Senih",
   "contributors": [

--- a/src/services/bankStatementMatch.js
+++ b/src/services/bankStatementMatch.js
@@ -1,6 +1,6 @@
 /*************************************************************************************
  * Product: ADempiere gRPC Bank Statement Match Client                               *
- * Copyright (C) 2012-2023 E.R.P. Consultores y Asociados, C.A.                      *
+ * Copyright (C) 2018-2023 E.R.P. Consultores y Asociados, C.A.                      *
  * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com                      *
  * This program is free software: you can redistribute it and/or modify              *
  * it under the terms of the GNU General Public License as published by              *

--- a/src/utils/valueUtils.js
+++ b/src/utils/valueUtils.js
@@ -128,12 +128,17 @@ function getTimestamp(dateValue) {
   if (typeOfValue === 'Date') {
     return dateValue.getTime();
   }
-  else if (typeOfValue === 'String' || typeOfValue == 'Number') {
-    value = Date.parse(dateValue);
-    // value = new Date(dateValue)
+  else if (typeOfValue === 'String') {
+    if (!isNaN(dateValue)) {
+      value = Number(dateValue);
+    } else {
+      value = Date.parse(dateValue);
+    }
+  } else if (typeOfValue == 'Number') {
+    value = dateValue;
   }
   if (isNaN(value)) {
-    value = 0
+    value = 0;
   }
 
   return value;


### PR DESCRIPTION
When values are sent by the query when it is an http GET method, the numbers are received as string type.

So when casting the date, it generated a `NaN` value, therefore the empty date to the backend
